### PR TITLE
Add a property to Field nodes

### DIFF
--- a/luaparser/astnodes.py
+++ b/luaparser/astnodes.py
@@ -408,10 +408,11 @@ class Field(Expression):
         key (`Expression`): Key.
         value (`Expression`): Value.
     """
-    def __init__(self, key, value, comments=[]):
+    def __init__(self, key, value, comments=[], between_brackets=False):
         super(Field, self).__init__('Field', comments)
         self.key = key
         self.value = value
+        self.between_brackets = between_brackets
 
 
 class Dots(Expression):

--- a/luaparser/builder.py
+++ b/luaparser/builder.py
@@ -1245,7 +1245,7 @@ class Builder:
                     value = self.parse_expr()
                     if value:
                         self.success()
-                        return Field(key, value, comments)
+                        return Field(key, value, comments, between_brackets=True)
 
         self.failure_save()
         if self.next_is_rc(Tokens.NAME):


### PR DESCRIPTION
This property is a boolean that tells if the key was written between brackets. The utility is when you need to tell the difference between these two cases: t = {key = 5, [key] = 2}, where t could be indexed with a string (t.key or t['key']) but also with whatever the value of the variable key could be.

Here's a working example 
```lua
local key = 'hello'
local a = {key = 'abc'}
local b = {[key] = 123}

print(a.key) -- > abc
print(b.key) -- > nil
print(b.hello) -- > 123
```

This is just a quick fix I made in order to keep up my other project, so feel free to come up with another solution.

For example, another way to solve this would be to treat it like the [grammar reference](http://www.lua.org/manual/5.1/manual.html#2.5.7) does
```field ::= `[´ exp `]´ `=´ exp | Name `=´ exp | exp```
So it could have element-like field for lists, a named-pair (for key=value) and a Pair (for [expression] = value) 