### PR TITLE
Instance of a base unnamed Exception

### DIFF
--- a/luaparser/builder.py
+++ b/luaparser/builder.py
@@ -164,7 +164,7 @@ class Builder:
         node = self.parse_chunk()
 
         if not node:
-            raise Exception("Expecting a chunk")
+            raise SyntaxException("Expecting a chunk")
         return node
 
     def save(self):


### PR DESCRIPTION
Hey. I just tried to add some handling of broken Lua code to my app and I noticed that there's one place that raises a base Exception() instead of a custom one.

Seems like SyntaxException from the same file fits this purpose, so here's a PR with a fix.

Cheers!