### PR TITLE
Fix two issues with ast.to_lua_source()

### DIFF
--- a/luaparser/printers.py
+++ b/luaparser/printers.py
@@ -317,7 +317,10 @@ class LuaOutputVisitor:
 
     @visit.register
     def visit(self, node: Return) -> str:
-        return "return " + self.do_visit(node.values)
+        res = self.do_visit(node.values)
+        if res == "False":
+            return "return"
+        return "return " + res
 
     @visit.register
     def visit(self, node: Fornum) -> str:

--- a/luaparser/printers.py
+++ b/luaparser/printers.py
@@ -265,7 +265,10 @@ class LuaOutputVisitor:
 
     @visit.register
     def visit(self, node: LocalAssign) -> str:
-        return "local " + self.do_visit(node.targets) + " = " + self.do_visit(node.values)
+        res = self.do_visit(node.values)
+        if res == '':
+            return "local " + self.do_visit(node.targets)
+        return "local " + self.do_visit(node.targets) + " = " + res
 
     @visit.register
     def visit(self, node: While) -> str:


### PR DESCRIPTION
This pull request is fixing two issues I've been encountering while using `ast.to_lua_source()` and for which you have issues opened:
1) When parsing a return statement that doesn't return a value, the resulting code will be: `return False` instead of `return` #44
2) When parsing a local assignment without a value, the resulting code will be: `local some_var =` instead of `local some_var` #37

I'm not sure if my patch is the good way to do it, but at least I tested it and it's working as expected.
Please let me know if I should change anything to get my pull-request accepted.