### PR TITLE
fix: multimethod not declared in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     ],
     install_requires=[
         'antlr4-python3-runtime<=4.7.2',
+        'multimethod'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This commit fixed a bug introduced in f43b5cdcb5cf0ad1e58fac22e3676ce1545ccb8c.

Signed-off-by: Zephyr Lykos <git@mochaa.ws>
