### PR TITLE
Get rid of printing AST from parse()

### DIFF
--- a/luaparser/ast.py
+++ b/luaparser/ast.py
@@ -28,7 +28,6 @@ def parse(source: str) -> Chunk:
     else:
         v = BuilderVisitor(token_stream)
         val = v.visit(tree)
-        print(val)
         return val
 
 


### PR DESCRIPTION
Solves #60 