### PR TITLE
Fixed rendering numeric concatenation. Added numeric concatenation test.

### DIFF
--- a/luaparser/printers.py
+++ b/luaparser/printers.py
@@ -539,7 +539,7 @@ class LuaOutputVisitor:
 
     @visit.register
     def visit(self, node: Concat) -> str:
-        return self.do_visit(node.left) + ".." + self.do_visit(node.right)
+        return self.do_visit(node.left) + " .. " + self.do_visit(node.right)
 
     @visit.register
     def visit(self, node: UMinusOp) -> str:

--- a/luaparser/tests/test_expressions.py
+++ b/luaparser/tests/test_expressions.py
@@ -359,8 +359,8 @@ class ExpressionsTestCase(tests.TestCase):
     """ 3.4.6 – Concatenation                                                   """
     """ ----------------------------------------------------------------------- """
 
-    def test_concatenation(self):
-        tree = ast.parse(r'str = "begin".."end"')
+    def test_string_concatenation(self):
+        tree = ast.parse(r'str = "begin" .. "end"')
         exp = Chunk(
             Block(
                 [
@@ -370,6 +370,25 @@ class ExpressionsTestCase(tests.TestCase):
                             Concat(
                                 left=String("begin", StringDelimiter.DOUBLE_QUOTE),
                                 right=String("end", StringDelimiter.DOUBLE_QUOTE),
+                            )
+                        ],
+                    )
+                ]
+            )
+        )
+        self.assertEqual(exp, tree)
+
+    def test_number_concatenation(self):
+        tree = ast.parse(r'str = 1 .. 2')
+        exp = Chunk(
+            Block(
+                [
+                    Assign(
+                        targets=[Name("str")],
+                        values=[
+                            Concat(
+                                left=Number(1),
+                                right=Number(2),
                             )
                         ],
                     )


### PR DESCRIPTION
The string `str = 1 .. 2` is parsed correctly, but rendered incorrectly. When the space between both numbers is preserved Lua assigns `"12"` to the `str` variable. When the spaces are not preserved Lua tries to parse the trailing `..` as a part of the first number. I noticed this while processing a large set of scripts.