### PR TITLE
Add AST tree replacement class

### DIFF
--- a/luaparser/ast.py
+++ b/luaparser/ast.py
@@ -111,14 +111,14 @@ class ASTReplaceVisitor:
                     if new_node != None:
                         for key in parent.__dict__.keys():
                             # if key == 'values' or key == 'args':
-                                obj_list = getattr(parent, key, None)
-                                if isinstance(obj_list, list):
+                                obj = getattr(parent, key, None)
+                                if isinstance(obj, list):
                                     for i, item in enumerate(obj_list):
                                         # print(item)
                                         if item is node:
                                             obj_list[i] = new_node
 
-                                elif getattr(parent, key, None) is node:
+                                elif obj is node:
                                     setattr(parent, key, new_node)
 
                 children = [

--- a/luaparser/ast.py
+++ b/luaparser/ast.py
@@ -110,15 +110,16 @@ class ASTReplaceVisitor:
                     new_node = tree_visitor(node)
                     if new_node != None:
                         for key in parent.__dict__.keys():
-                            if key == 'values' or key == 'args':
+                            # if key == 'values' or key == 'args':
                                 obj_list = getattr(parent, key, None)
-                                for i, item in enumerate(obj_list):
-                                    # print(item)
-                                    if item is node:
-                                        obj_list[i] = new_node
+                                if isinstance(obj_list, list):
+                                    for i, item in enumerate(obj_list):
+                                        # print(item)
+                                        if item is node:
+                                            obj_list[i] = new_node
 
-                            elif getattr(parent, key, None) is node:
-                                setattr(parent, key, new_node)
+                                elif getattr(parent, key, None) is node:
+                                    setattr(parent, key, new_node)
 
                 children = [
                     attr for attr in node.__dict__.keys() if not attr.startswith("_")

--- a/luaparser/ast.py
+++ b/luaparser/ast.py
@@ -113,10 +113,10 @@ class ASTReplaceVisitor:
                             # if key == 'values' or key == 'args':
                                 obj = getattr(parent, key, None)
                                 if isinstance(obj, list):
-                                    for i, item in enumerate(obj_list):
+                                    for i, item in enumerate(obj):
                                         # print(item)
                                         if item is node:
-                                            obj_list[i] = new_node
+                                            obj[i] = new_node
 
                                 elif obj is node:
                                     setattr(parent, key, new_node)

--- a/luaparser/ast.py
+++ b/luaparser/ast.py
@@ -94,6 +94,41 @@ class JSONEncoder(json.JSONEncoder):
 def to_pretty_json(root: Node) -> str:
     return json.dumps(root, cls=JSONEncoder, indent=4)
 
+class ASTReplaceVisitor:
+    def visit(self, root):
+        if root is None:
+            return
+        node_stack = [(root, None)]
+
+        while len(node_stack) > 0:
+            node, parent = node_stack.pop()
+            
+            if isinstance(node, astnodes.Node):
+                name = "visit_" + node.__class__.__name__
+                tree_visitor = getattr(self, name, None)
+                if tree_visitor:
+                    new_node = tree_visitor(node)
+                    if new_node != None:
+                        for key in parent.__dict__.keys():
+                            if key == 'values' or key == 'args':
+                                obj_list = getattr(parent, key, None)
+                                for i, item in enumerate(obj_list):
+                                    # print(item)
+                                    if item is node:
+                                        obj_list[i] = new_node
+
+                            elif getattr(parent, key, None) is node:
+                                setattr(parent, key, new_node)
+
+                children = [
+                    attr for attr in node.__dict__.keys() if not attr.startswith("_")
+                ]
+                for child in reversed(children):
+                    node_stack.append((node.__dict__[child], node))
+                    
+            elif isinstance(node, list):
+                for n in reversed(node):
+                    node_stack.append((n, parent))
 
 class ASTVisitor:
     def visit(self, root):


### PR DESCRIPTION
Support for replacing the current node during Visitor traversal.

---

While using it, I wanted to edit the tree to deobfuscate Lua code, but it seems editing functionality is not supported—only traversal is allowed. Of course, it's also possible that I'm not using it correctly. If that's the case, please close this issue. Currently, the code runs well in my project, though I’m not sure if there are any unknown bugs.

``` python
class NumberVisitor(ast.ASTReplaceVisitor):
    def visit_Number(self, node):
        # Replace all Number types with a Number type of value 123. Of course, other types can be returned here, or conditional filtering can be applied.
        return ast.Number(123)
        # If it is not necessary to replace the current one
        # return None
```