### PR TITLE
fix: replace walrus operator for Python 3.6 compatibility

### DIFF
--- a/luaparser/builder.py
+++ b/luaparser/builder.py
@@ -681,9 +681,11 @@ class BuilderVisitor(LuaParserVisitor):
             lua_str = lua_str[1:-1]
             delimiter = StringDelimiter.SINGLE_QUOTE
         # double square brackets notation:
-        elif m := LUA_DOUBLE_SQUARE_RE.match(lua_str):
-            lua_str = m.group("body")
-            delimiter = StringDelimiter.DOUBLE_SQUARE
+        else:
+            m = LUA_DOUBLE_SQUARE_RE.match(lua_str)
+            if m:
+                lua_str = m.group("body")
+                delimiter = StringDelimiter.DOUBLE_SQUARE
 
         if delimiter == StringDelimiter.DOUBLE_QUOTE or delimiter == StringDelimiter.SINGLE_QUOTE:
             unescaped_str = unescape_lua_string(lua_str)


### PR DESCRIPTION
## What Problem This Solves

The walrus operator (`:=`) was introduced in Python 3.8. The project declares support for Python 3.6 and 3.7 in setup.py classifiers, but the walrus operator at `builder.py:684` would break on those versions.

## Why This Change Was Made

Replace the walrus operator with a traditional two-line assignment pattern — an `else` block with an explicit `if m:` check. This is functionally identical but compatible with Python 3.6+.

## User Impact

Users on Python 3.6 and 3.7 can now use luaparser without hitting a syntax error.

## Evidence

- All 147 tests pass
- Double-square-bracket strings continue to parse correctly

Fixes #77